### PR TITLE
Create NameserverLookup.md

### DIFF
--- a/golang/NameserverLookup.md
+++ b/golang/NameserverLookup.md
@@ -10,6 +10,7 @@ nameserver, _ := net.LookupNS("github.com")
 	for _, nserver := range nameserver {
 		fmt.Println(nserver)
 	}
+```
   
 - import the net package which provides a portable interface for network I/O and the fmt to print out the nserver
 - net.LookupNS() returns the domain name server for the given web address

--- a/golang/NameserverLookup.md
+++ b/golang/NameserverLookup.md
@@ -12,5 +12,6 @@ nameserver, _ := net.LookupNS("github.com")
 	}
 ```
   
+  
 - import the net package which provides a portable interface for network I/O and the fmt to print out the nserver
 - net.LookupNS() returns the domain name server for the given web address

--- a/golang/NameserverLookup.md
+++ b/golang/NameserverLookup.md
@@ -1,0 +1,15 @@
+#Find the nameserver records of a domain name
+
+```Go
+import (
+        "net"
+        "fmt"
+        )
+
+nameserver, _ := net.LookupNS("github.com")
+	for _, nserver := range nameserver {
+		fmt.Println(nserver)
+	}
+  
+- import the net package which provides a portable interface for network I/O and the fmt to print out the nserver
+- net.LookupNS() returns the domain name server for the given web address


### PR DESCRIPTION
# The snippet uses net.LookupNS() function  which takes a domain name as a string and returns its DNS-NS records