### PR TITLE
bash: add Binet's Formula

### DIFF
--- a/bash/binet.md
+++ b/bash/binet.md
@@ -1,0 +1,16 @@
+# Binet's Formula in bash
+
+```bash
+export n=1000 && export PHI="1.618033988749894848204586834365638117720309179805762862135448622705260462818902449707207204189391137484754088075386891752126633862223536931793180060766726354433389086595939582905638322661319928290267880675208766892501711696" && export PSI=$(echo "1 - $PHI" | bc) && echo "Calculating Fn($n) via Binet's Formula" && 
+if [ $n -le 2 ]; then echo "( ($PHI^$n - $PSI^$n) / ($PHI - $PSI) )" | bc;
+else time echo "( ($PHI^$n - $PSI^$n) / ($PHI - $PSI) + 1 )" | bc; fi;
+```
+
+- export n, where n is the Fibonacci value to calculate
+- export PHI and PSI values
+- Fn is calculated via [Binet's Formula](https://en.wikipedia.org/wiki/Fibonacci_number#Binet's_formula)
+- There is no iteration or recursion with this method
+- Binet's Formula is piped to bc, the bash calculator
+- Have to do some trickery with rounding by adding 1
+- Note: For higher n values increase the decimal places of `PHI`
+- All one line, so just copy and paste


### PR DESCRIPTION
Adding Binet's Formula to the bash library.
- demonstrates how to use bash calculator
- calculate Fibonacci value without iteration or recursion
- possible use for CPU benchmarking

<details hidden><summary>log</summary>

    user@server:~/onelinerhub$ export n=1000 && export PHI="1.618033988749894848204586834365638117720309179805762862135448622705260462818902449707207204189391137484754088075386891752126633862223536931793180060766726354433389086595939582905638322661319928290267880675208766892501711696" && export PSI=$(echo "1 - $PHI" | bc) && echo "Calculating Fn($n) via Binet's Formula" &&  if [ $n -le 2 ]; then echo "( ($PHI^$n - $PSI^$n) / ($PHI - $PSI) )" | bc; else time echo "( ($PHI^$n - $PSI^$n) / ($PHI - $PSI) + 1 )" | bc; fi;
    Calculating Fn(1000) via Binet's Formula
    43466557686937456435688527675040625802564660517371780402481729089536\
    55541794905189040387984007925516929592259308032263477520968962323987\
    33224711616429964409065331879382989696499285160037044761377951668492\
    28875

    real    0m5.133s
    user    0m5.115s
    sys     0m0.013s

</details>