### PR TITLE
Modify how-to-convert-pointer-to-reference-in-rust.md so the code compiles

### DIFF
--- a/rust/how-to-convert-pointer-to-reference-in-rust.md
+++ b/rust/how-to-convert-pointer-to-reference-in-rust.md
@@ -1,16 +1,19 @@
 # How to convert pointer to reference in Rust
 // plain
 
-In Rust, you can convert a pointer to a reference by using the `&` operator. For example, if you have a pointer `p` to a type `T`, you can convert it to a reference by using `&p`. This will create a reference to the same value that the pointer points to. The output of this operation will be a reference of type `&T`.
+In Rust, you can convert a pointer to a reference by dereferencing the pointer with `*`, then creating a reference with `&`. For example, if you have a pointer `p` to a type `T`, you can convert it to a reference by using `&*p`. This will create a reference to the same value that the pointer points to. The output of this operation will be a reference of type `&T`.
 ```rust
 let p: *const i32 = &10;
-let r: &i32 = &p;
+
+unsafe {
+  let r: &i32 = &*p;
+}
 ```
 ### Output example
 This code will not produce any output.
 
 ### Explanation
-The `&` operator is used to convert a pointer to a reference. In this example, the pointer `p` is of type `*const i32`, which is a pointer to a constant integer. The `&` operator is used to convert this pointer to a reference of type `&i32`, which is a reference to an integer.
+The `&` operator is used to convert a pointer to a reference. In this example, the pointer `p` is of type `*const i32`, which is a pointer to a constant integer. The `*` in `&*p` is used to dereference `p`, then the `&` creates a reference to that location. This pointer to a reference of type `&i32`, which is a reference to an integer. The unsafe block is needed to dereference the raw pointer.
 
 ### Relevant links
 - [Rust Pointers](https://doc.rust-lang.org/book/ch19-01-pointers.html)


### PR DESCRIPTION
Previously, the code in <https://github.com/Onelinerhub/onelinerhub/blob/main//rust/how-to-convert-pointer-to-reference-in-rust.md> did not compile. (See Issue #2003 ). The new code compiles in [Rust Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&code=pub+fn+main%28%29+%7B%0A++++let+p%3A+*const+i32+%3D+%2610%3B%0A++++%0A++++unsafe+%7B%0A++++++let+r%3A+%26i32+%3D+%26*p%3B%0A++++%7D%0A%7D%0A).